### PR TITLE
Correção de Bug no ValorMonetarioTextWatcher e implementação do formatador e validador de CEP.

### DIFF
--- a/canarinho/src/main/java/br/com/concretesolutions/canarinho/formatador/Formatador.java
+++ b/canarinho/src/main/java/br/com/concretesolutions/canarinho/formatador/Formatador.java
@@ -10,6 +10,11 @@ public interface Formatador {
 
     // Formatadores
     /**
+     * Singleton de formatação de CEP
+     */
+    Formatador CEP = new FormatadorBase(Padroes.CEP_FORMATADO, "$1-$2", Padroes.CEP_DESFORMATADO, "$1$2");
+
+    /**
      * Singleton de formatação de CPF
      */
     Formatador CPF = new FormatadorBase(Padroes.CPF_FORMATADO, "$1.$2.$3-$4", Padroes.CPF_DESFORMATADO, "$1$2$3$4");
@@ -82,6 +87,10 @@ public interface Formatador {
      */
     abstract class Padroes {
         // Patterns
+        public static final Pattern CEP_FORMATADO = Pattern
+                .compile("(\\d{5})-(\\d{3})");
+        public static final Pattern CEP_DESFORMATADO = Pattern
+                .compile("(\\d{5})(\\d{3})");
         public static final Pattern CNPJ_FORMATADO = Pattern
                 .compile("(\\d{2})[.](\\d{3})[.](\\d{3})/(\\d{4})-(\\d{2})");
         public static final Pattern CNPJ_DESFORMATADO = Pattern

--- a/canarinho/src/main/java/br/com/concretesolutions/canarinho/formatador/FormatadorCEP.java
+++ b/canarinho/src/main/java/br/com/concretesolutions/canarinho/formatador/FormatadorCEP.java
@@ -1,0 +1,43 @@
+package br.com.concretesolutions.canarinho.formatador;
+
+/**
+ * Formata CEP
+ * Ver exemplos no Sample.
+ */
+public final class FormatadorCEP implements Formatador {
+
+    private FormatadorCEP() {
+    }
+
+    static FormatadorCEP getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
+
+    @Override
+    public String formata(final String value) {
+        return Formatador.CEP.formata(value);
+    }
+
+    @Override
+    public String desformata(final String value) {
+        return Formatador.CEP.desformata(value);
+    }
+
+    @Override
+    public boolean estaFormatado(final String value) {
+        return Formatador.CEP.estaFormatado(value);
+    }
+
+    @Override
+    public boolean podeSerFormatado(final String value) {
+        if (value == null) {
+            return false;
+        }
+
+        return Formatador.CEP.podeSerFormatado(value);
+    }
+
+    private static class SingletonHolder {
+        private static final FormatadorCEP INSTANCE = new FormatadorCEP();
+    }
+}

--- a/canarinho/src/main/java/br/com/concretesolutions/canarinho/validator/ValidadorCEP.java
+++ b/canarinho/src/main/java/br/com/concretesolutions/canarinho/validator/ValidadorCEP.java
@@ -1,0 +1,54 @@
+package br.com.concretesolutions.canarinho.validator;
+
+import android.text.Editable;
+
+import br.com.concretesolutions.canarinho.formatador.Formatador;
+
+/**
+ * Created by eduardo on 12/26/15.
+ */
+public final class ValidadorCEP implements Validador {
+
+    // No instance creation
+    private ValidadorCEP() {
+    }
+
+    public static ValidadorCEP getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
+
+    @Override
+    public boolean ehValido(String valor) {
+        if (valor == null || valor.length() < 8) {
+            return false;
+        }
+
+        final String desformatado = Formatador.Padroes.PADRAO_SOMENTE_NUMEROS.matcher(valor).replaceAll("");
+
+        return desformatado.length() == 8;
+    }
+
+    @Override
+    public ResultadoParcial ehValido(Editable valor, ResultadoParcial resultadoParcial) {
+        if (resultadoParcial == null || valor == null) {
+            throw new IllegalArgumentException("Valores não podem ser nulos");
+        }
+
+        final String desformatado = Formatador.Padroes.PADRAO_SOMENTE_NUMEROS.matcher(valor).replaceAll("");
+
+        if (!ehValido(desformatado)) {
+            return resultadoParcial
+                    .parcialmenteValido(desformatado.length() < 8)
+                    .mensagem("CEP inválido")
+                    .totalmenteValido(false);
+        }
+
+        return resultadoParcial
+                .parcialmenteValido(true)
+                .totalmenteValido(true);
+    }
+
+    private static class SingletonHolder {
+        private static final ValidadorCEP INSTANCE = new ValidadorCEP();
+    }
+}

--- a/canarinho/src/main/java/br/com/concretesolutions/canarinho/watcher/CEPTextWatcher.java
+++ b/canarinho/src/main/java/br/com/concretesolutions/canarinho/watcher/CEPTextWatcher.java
@@ -1,0 +1,176 @@
+package br.com.concretesolutions.canarinho.watcher;
+
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.Selection;
+import android.text.TextWatcher;
+
+import br.com.concretesolutions.canarinho.formatador.Formatador;
+import br.com.concretesolutions.canarinho.validator.Validador;
+import br.com.concretesolutions.canarinho.validator.ValidadorCEP;
+import br.com.concretesolutions.canarinho.watcher.evento.EventoDeValidacao;
+
+/**
+ * {@link TextWatcher} responsável por formatar e validar um {@link android.widget.EditText} para CEPs.
+ * Para usar este componente basta criar uma instância e chamar
+ * {@link android.widget.EditText#addTextChangedListener(TextWatcher)}.
+ */
+public final class CEPTextWatcher implements TextWatcher {
+
+    private static final char[] CEP_DIGITOS = "#####-###".toCharArray();
+
+    private static final InputFilter[] FILTRO_OITO_DIGITOS = new InputFilter[]{
+            new InputFilter.LengthFilter(CEP_DIGITOS.length)};
+
+    private final Validador validador = ValidadorCEP.getInstance();
+    private final Validador.ResultadoParcial resultadoParcial = new Validador.ResultadoParcial();
+    private EventoDeValidacao callbackErros;
+
+    private boolean mudancaInterna = false;
+    private int tamanhoAnterior = 0;
+
+    /**
+     * TODO Javadoc pendente
+     */
+    public CEPTextWatcher() {
+
+    }
+
+    /**
+     * TODO Javadoc pendente
+     *
+     * @param callbackErros a descrever
+     */
+    public CEPTextWatcher(EventoDeValidacao callbackErros) {
+        this.callbackErros = callbackErros;
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        // Não faz nada aqui
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        // Não faz nada aqui
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+
+        if (mudancaInterna) {
+            return;
+        }
+
+        s.setFilters(FILTRO_OITO_DIGITOS);
+
+        final boolean apagou = tamanhoAnterior > s.length();
+
+        final StringBuilder builder = apagou
+                ? trataRemocaoDeCaracter(s, CEP_DIGITOS)
+                : trataAdicaoDeCaracter(s, CEP_DIGITOS);
+
+        tamanhoAnterior = builder.length();
+        atualizaTexto(s, builder);
+    }
+
+    // CUIDADO AO ATUALIZAR O Editable AQUI!!!
+    private void efetuaValidacao(Editable s) {
+        validador.ehValido(s, resultadoParcial);
+
+        if (callbackErros == null) {
+            return;
+        }
+
+        if (!resultadoParcial.isParcialmenteValido()) {
+            callbackErros.invalido(s.toString(), resultadoParcial.getMensagem());
+        } else {
+
+            if (!resultadoParcial.isValido()) {
+                callbackErros.parcialmenteValido(s.toString());
+            } else {
+                callbackErros.totalmenteValido(s.toString());
+            }
+        }
+    }
+
+    // Usa o Editable para atualizar o Editable
+    // O cursor SEMPRE sera posicionado no final do conteúdo
+    private void atualizaTexto(Editable s, StringBuilder builder) {
+        mudancaInterna = true;
+        s.replace(0, s.length(), builder, 0, builder.length());
+
+        if (builder.toString().equals(s.toString())) {
+            // TODO: estudar implantar a manutenção da posição do cursor
+            Selection.setSelection(s, builder.length());
+        }
+
+        efetuaValidacao(s);
+
+        mudancaInterna = false;
+    }
+
+    private StringBuilder trataAdicaoDeCaracter(Editable s, char[] mascara) {
+        return carregarMascara(s.toString(), mascara);
+    }
+
+    private StringBuilder carregarMascara(String s, char[] mascara) {
+        final StringBuilder builder = new StringBuilder();
+        final String str = Formatador.Padroes.PADRAO_SOMENTE_NUMEROS.matcher(s).replaceAll("");
+
+        // Só carregará a máscara se existir algum valor informado
+        if (str.length() > 0) {
+            int j = 0; // Acompanha a posição nos dígitos
+
+            // É recomendado não usar enhanced for em Android
+            for (int i = 0; i < mascara.length; i++) {
+
+                final char charMascara = mascara[i];
+
+                if (charMascara != '#') { // '#' -> caracter de formatação
+                    builder.append(charMascara);
+                    continue;
+                }
+
+                if (j >= str.length()) {
+                    break;
+                }
+
+                builder.append(str.charAt(j));
+                j++;
+            }
+        }
+
+        return builder;
+    }
+
+    // Só é chamado após uma deleção, portanto, é seguro chamar mascara[s.length()]
+    private StringBuilder trataRemocaoDeCaracter(Editable s, char[] mascara) {
+        final StringBuilder builder = new StringBuilder(s);
+
+        // Obtém a posição do último caracter excluído
+        final int posicaoUltimoCaracter = mascara.length > s.length() ? s.length() : mascara.length - 1;
+
+        // Verifica se o último caracter que foi excluído fazia parte da máscara
+        final boolean ultimoCaracterEraMascara = mascara[posicaoUltimoCaracter] != '#';
+
+        // Se o último caracter excluido fazia parte da máscara,
+        // deve excluir até o primeiro caracter que não faz parte da máscara
+        if (ultimoCaracterEraMascara) {
+            boolean encontrouCaracterValido = false;
+            while (builder.length() > 0 && !encontrouCaracterValido) {
+                encontrouCaracterValido = mascara[builder.length() - 1] == '#';
+                builder.deleteCharAt(builder.length() - 1);
+            }
+        }
+
+        // Caso haja mais de um caracter de formatação (da máscara) faz um loop
+        // até chegar em um caracter que não seja de formatação
+        while (builder.length() > 0 && mascara[builder.length() - 1] != '#') {
+            builder.deleteCharAt(builder.length() - 1);
+        }
+
+        return carregarMascara(builder.toString(), mascara);
+    }
+
+}

--- a/canarinho/src/main/java/br/com/concretesolutions/canarinho/watcher/ValorMonetarioWatcher.java
+++ b/canarinho/src/main/java/br/com/concretesolutions/canarinho/watcher/ValorMonetarioWatcher.java
@@ -1,22 +1,17 @@
 package br.com.concretesolutions.canarinho.watcher;
 
 import android.text.Editable;
-import android.text.InputFilter;
 import android.text.Selection;
 import android.text.TextWatcher;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.text.DecimalFormat;
 
 import br.com.concretesolutions.canarinho.formatador.Formatador;
 
 /**
  */
 public final class ValorMonetarioWatcher implements TextWatcher {
-
-    private static final DecimalFormat DUAS_CASAS = new DecimalFormat("##.00");
-
     private boolean mudancaInterna;
 
     @Override
@@ -37,16 +32,20 @@ public final class ValorMonetarioWatcher implements TextWatcher {
         }
 
         final String somenteNumeros = Formatador.Padroes.PADRAO_SOMENTE_NUMEROS.matcher(s.toString()).replaceAll("");
-        final BigDecimal resultado = new BigDecimal(somenteNumeros).divide(new BigDecimal(100))
-                .setScale(2, RoundingMode.HALF_DOWN);
 
-        atualizaTexto(s, Formatador.VALOR.formata(resultado.toPlainString()));
+        // afterTextChanged é chamado ao rotacionar o dispositivo,
+        // essa condição evita que ao rotacionar a tela com o campo vazio ocorra NumberFormatException
+        if (somenteNumeros.length() != 0) {
+            final BigDecimal resultado = new BigDecimal(somenteNumeros).divide(new BigDecimal(100))
+                    .setScale(2, RoundingMode.HALF_DOWN);
+
+            atualizaTexto(s, Formatador.VALOR.formata(resultado.toPlainString()));
+        }
     }
 
     private void atualizaTexto(Editable s, String valor) {
         mudancaInterna = true;
 
-        final InputFilter[] filters = s.getFilters();
         s.replace(0, s.length(), valor);
 
         if (valor.equals(s.toString())) {

--- a/sample/src/androidTest/java/br/com/concretesolutions/canarinho/sample/DemoWatchersInstrumentationTest.java
+++ b/sample/src/androidTest/java/br/com/concretesolutions/canarinho/sample/DemoWatchersInstrumentationTest.java
@@ -215,4 +215,23 @@ public class DemoWatchersInstrumentationTest {
         onView(withText("CNPJ inválido")).check(matches(isDisplayed()));
     }
 
+    @Test
+    public void consegueDigitarUmCEPValido() throws Throwable {
+        final NestedScrollView scroll = (NestedScrollView) rule.getActivity().findViewById(R.id.container);
+
+        rule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                scroll.fullScroll(View.FOCUS_DOWN);
+            }
+        });
+
+        Thread.sleep(2000L);
+        onView(withId(R.id.edit_cep)).perform(typeText("49025090"));
+
+        onView(withText("Campo válido!"))
+                .check(matches(isDisplayed()))
+                .perform(pressBack());
+    }
+
 }

--- a/sample/src/main/java/br/com/concretesolutions/canarinho/sample/DemoWatchersActivity.java
+++ b/sample/src/main/java/br/com/concretesolutions/canarinho/sample/DemoWatchersActivity.java
@@ -9,6 +9,7 @@ import android.widget.EditText;
 
 import br.com.concretesolutions.canarinho.validator.Validador;
 import br.com.concretesolutions.canarinho.watcher.BoletoBancarioTextWatcher;
+import br.com.concretesolutions.canarinho.watcher.CEPTextWatcher;
 import br.com.concretesolutions.canarinho.watcher.CPFCNPJTextWatcher;
 import br.com.concretesolutions.canarinho.watcher.MascaraNumericaTextWatcher;
 import br.com.concretesolutions.canarinho.watcher.TelefoneTextWatcher;
@@ -24,12 +25,14 @@ public class DemoWatchersActivity extends AppCompatActivity {
     private EditText editTelefone;
     private EditText editValor;
     private EditText editCPFCNPJ;
+    private EditText editCEP;
 
     private TextInputLayout editLayoutBoleto;
     private TextInputLayout editLayoutCPF;
     private TextInputLayout editLayoutCNPJ;
     private TextInputLayout editLayoutTelefone;
     private TextInputLayout editLayoutCPFCNPJ;
+    private TextInputLayout editLayoutCEP;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -45,12 +48,14 @@ public class DemoWatchersActivity extends AppCompatActivity {
         editTelefone = (EditText) findViewById(R.id.edit_telefone);
         editValor = (EditText) findViewById(R.id.edit_valor);
         editCPFCNPJ = (EditText) findViewById(R.id.edit_cpf_cnpj);
+        editCEP = (EditText) findViewById(R.id.edit_cep);
 
         editLayoutBoleto = (TextInputLayout) findViewById(R.id.edit_layout_boleto);
         editLayoutCPF = (TextInputLayout) findViewById(R.id.edit_layout_cpf);
         editLayoutCNPJ = (TextInputLayout) findViewById(R.id.edit_layout_cnpj);
         editLayoutTelefone = (TextInputLayout) findViewById(R.id.edit_layout_telefone);
         editLayoutCPFCNPJ = (TextInputLayout) findViewById(R.id.edit_layout_cpf_cnpj);
+        editLayoutCEP = (TextInputLayout) findViewById(R.id.edit_layout_cep);
 
         editBoleto.addTextChangedListener(new BoletoBancarioTextWatcher(geraParaCampo(editLayoutBoleto)));
         editCPF.addTextChangedListener(new MascaraNumericaTextWatcher.Builder()
@@ -66,6 +71,7 @@ public class DemoWatchersActivity extends AppCompatActivity {
         editTelefone.addTextChangedListener(new TelefoneTextWatcher(geraParaCampo(editLayoutTelefone)));
         editValor.addTextChangedListener(new ValorMonetarioWatcher());
         editCPFCNPJ.addTextChangedListener(new CPFCNPJTextWatcher(geraParaCampo(editLayoutCPFCNPJ)));
+        editCEP.addTextChangedListener(new CEPTextWatcher(geraParaCampo(editLayoutCEP)));
     }
 
     private EventoDeValidacao geraParaCampo(final TextInputLayout campo) {

--- a/sample/src/main/res/layout/demo_watcher_activity.xml
+++ b/sample/src/main/res/layout/demo_watcher_activity.xml
@@ -160,6 +160,26 @@
 
             </android.support.v7.widget.CardView>
 
+            <android.support.v7.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp">
+
+                <android.support.design.widget.TextInputLayout
+                    android:id="@+id/edit_layout_cep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="12dp"
+                    app:errorEnabled="true">
+
+                    <EditText
+                        android:id="@+id/edit_cep"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Digite um CEP válido" />
+                </android.support.design.widget.TextInputLayout>
+
+            </android.support.v7.widget.CardView>
         </LinearLayout>
     </android.support.v4.widget.NestedScrollView>
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
@cs-victor-nascimento:
-Adicionei o formatador e validador de CEP.
-Consertei um erro que ocorria ao rotacionar a tela com um EditText vazio que possui como TextWatcher ValorMonetarioTextWatcher. O afterTextChanged era chamado e tentava converter uma String vazia em um BigDecimal dando NumberFormatException.

Ignora meu pull-request anterior acabei enviando o arquivo editado errado.